### PR TITLE
Fix regex for file/line/method matches when processing an exception's backtrace

### DIFF
--- a/lib/application_insights/telemetry_client.rb
+++ b/lib/application_insights/telemetry_client.rb
@@ -79,7 +79,7 @@ module ApplicationInsights
 
       parsed_stack = []
       if exception.backtrace
-        frame_pattern = /^(?<file>.*):(?<line>\d+)(\.|:in `((?<method>.*)'$))/
+        frame_pattern = /^(?<file>.*):(?<line>\d+)(\.|:in '((?<method>.*)'$))/
 
         exception.backtrace.each_with_index do |frame, counter|
           match = frame_pattern.match frame


### PR DESCRIPTION
Our exception handling is being thwarted by an error in ApplicationInsights own exception handling. We need to fix this as we require AppInsights for general telemetry and metrics.

`TelemetryClient#track_exception` is throwing a `undefined method '[]' for nil` error, coming out of:

```
/usr/local/bundle/gems/application_insights-0.5.6/lib/application_insights/telemetry_client.rb:86
:in 'block in ApplicationInsights::TelemetryClient#track_exception'
```

This is due to a failure in the regex which attempts to capture:

- file
- line
- method

from each line in the backtrace. Given:

`/home/roger/.local/share/mise/installs/ruby/3.4.1/lib/ruby/gems/3.4.0/gems/activerecord-sqlserver-adapter-7.1.11/lib/active_record/connection_adapters/sqlserver/database_statements.rb:429:in 'TinyTds::Result#each'`

we expect the match groups:

|        |                                                                                                                                                                                         |
| ------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
| file   | /home/roger/.local/share/mise/installs/ruby/3.4.1/lib/ruby/gems/3.4.0/gems/activerecord-sqlserver-adapter-7.1.11/lib/active_record/connection_adapters/sqlserver/database_statements.rb |
| line   | 429                                                                                                                                                                                     |
| method | TinyTds::Result#each                                                                                                                                                                    |

By replacing the backtick in the regex:

```
/^(?<file>.*):(?<line>\d+)(\.|:in `((?<method>.*)'$))/
```

 with a single quote, the matcher behaves as expected.